### PR TITLE
switch map to sandbox

### DIFF
--- a/launch/map_server.launch
+++ b/launch/map_server.launch
@@ -1,5 +1,5 @@
 <launch>
-    <arg name="map" default="$(find mushr_sim)/maps/real-floor0.yaml"/>
+    <arg name="map" default="$(find mushr_sim)/maps/sandbox.yaml"/>
     <node pkg="map_server" name="map_server" type="map_server" args="$(arg map)" />
     <param name="/map_file" value="$(arg map)" />
 </launch>


### PR DESCRIPTION
Switched the default map to sandbox so users do not think their car doesn't move. The old map put the car in a wall so teleop seemed to not work