### PR TITLE
Add default namespace

### DIFF
--- a/launch/single_car.launch
+++ b/launch/single_car.launch
@@ -1,6 +1,6 @@
 <launch>
 
-    <arg name="car_name" default="car"/>
+    <arg name="car_name" default="car" />
 
     <!-- Could be racecar-mit, racecar-uw-tx2, or racecar-uw-nano -->
     <arg name="racecar_version" default="racecar-uw-nano" />
@@ -40,7 +40,7 @@
         <!-- Start electronic speed controller driver -->
         <include file="$(find mushr_sim)/launch/vesc.launch.xml" >
             <arg name="mux_output_topic" value="/$(arg car_name)/mux/ackermann_cmd_mux/output" />
-            <arg name="car_name" value="/$(arg car_name)"/>
+            <arg name="car_name" value="/$(arg car_name)" />
         </include>
     </group>
 

--- a/launch/single_car.launch
+++ b/launch/single_car.launch
@@ -40,6 +40,7 @@
         <!-- Start electronic speed controller driver -->
         <include file="$(find mushr_sim)/launch/vesc.launch.xml" >
             <arg name="mux_output_topic" value="/$(arg car_name)/mux/ackermann_cmd_mux/output"/>
+            <arg name="car_name" value="$(arg car_name)"/>
         </include>
     </group>
 

--- a/launch/single_car.launch
+++ b/launch/single_car.launch
@@ -1,6 +1,6 @@
 <launch>
 
-    <arg name="car_name" default=""/>
+    <arg name="car_name" default="car"/>
 
     <!-- Could be racecar-mit, racecar-uw-tx2, or racecar-uw-nano -->
     <arg name="racecar_version" default="racecar-uw-nano" />
@@ -39,8 +39,8 @@
     <group ns="vesc">
         <!-- Start electronic speed controller driver -->
         <include file="$(find mushr_sim)/launch/vesc.launch.xml" >
-            <arg name="mux_output_topic" value="/$(arg car_name)/mux/ackermann_cmd_mux/output"/>
-            <arg name="car_name" value="$(arg car_name)"/>
+            <arg name="mux_output_topic" value="/$(arg car_name)/mux/ackermann_cmd_mux/output" />
+            <arg name="car_name" value="/$(arg car_name)"/>
         </include>
     </group>
 
@@ -49,6 +49,5 @@
         <arg name="racecar_version" value="$(arg racecar_version)" />
         <arg name="tf_prefix" value="$(arg car_name)"/>
     </include>
-
 
 </launch>

--- a/launch/teleop.launch
+++ b/launch/teleop.launch
@@ -4,19 +4,26 @@
     <!-- Set to 1 if you want to run the map_server -->
     <arg name="map_server" value = "1"/>
 
+    <arg name="car_name" default="car"/>
+
     <!-- Launch  map server-->
     <group if="$(arg map_server)">
         <include file="$(find mushr_sim)/launch/map_server.launch" />
     </group>
 
     <!-- Launch car -->
-    <include file="$(find mushr_sim)/launch/single_car.launch">
-    <!-- Could be racecar-mit, racecar-uw-tx2, or racecar-uw-nano -->
-        <arg name="racecar_version" value="racecar-uw-nano"/>
-        <!-- The colors of the racecar, should be of the form "-<platform_color>-<inset_color>" -->
-        <!-- An empty string will result in the default URDF -->
-	      <!-- Check CMakeLists.txt of mushr_description for appropriate values -->
-        <arg name="racecar_color" value="" />
-     </include>
+
+    <group ns="$(arg car_name)">
+        <include file="$(find mushr_sim)/launch/single_car.launch">
+            <!-- Could be racecar-mit, racecar-uw-tx2, or racecar-uw-nano -->
+            <arg name="racecar_version" value="racecar-uw-nano"/>
+            <!-- The colors of the racecar, should be of the form "-<platform_color>-<inset_color>" -->
+            <!-- An empty string will result in the default URDF -->
+              <!-- Check CMakeLists.txt of mushr_description for appropriate values -->
+            <arg name="racecar_color" value="" />
+
+            <arg name="car_name" value="$(arg car_name)" />
+         </include>
+    </group>
 
 </launch>

--- a/launch/teleop.launch
+++ b/launch/teleop.launch
@@ -14,6 +14,8 @@
     <!-- Launch car -->
 
     <group ns="$(arg car_name)">
+        <remap from="/$(arg car_name)/initialpose" to="/initialpose" />
+
         <include file="$(find mushr_sim)/launch/single_car.launch">
             <!-- Could be racecar-mit, racecar-uw-tx2, or racecar-uw-nano -->
             <arg name="racecar_version" value="racecar-uw-nano" />

--- a/launch/teleop.launch
+++ b/launch/teleop.launch
@@ -2,9 +2,9 @@
 <launch>
 
     <!-- Set to 1 if you want to run the map_server -->
-    <arg name="map_server" value = "1"/>
+    <arg name="map_server" value = "1" />
 
-    <arg name="car_name" default="car"/>
+    <arg name="car_name" default="car" />
 
     <!-- Launch  map server-->
     <group if="$(arg map_server)">
@@ -16,7 +16,7 @@
     <group ns="$(arg car_name)">
         <include file="$(find mushr_sim)/launch/single_car.launch">
             <!-- Could be racecar-mit, racecar-uw-tx2, or racecar-uw-nano -->
-            <arg name="racecar_version" value="racecar-uw-nano"/>
+            <arg name="racecar_version" value="racecar-uw-nano" />
             <!-- The colors of the racecar, should be of the form "-<platform_color>-<inset_color>" -->
             <!-- An empty string will result in the default URDF -->
               <!-- Check CMakeLists.txt of mushr_description for appropriate values -->

--- a/launch/vesc.launch.xml
+++ b/launch/vesc.launch.xml
@@ -2,6 +2,8 @@
 <launch>
     <arg name="mux_output_topic" default="ackermann_cmd" />
     <arg name="vesc_config" default="$(find mushr_sim)/config/vesc.yaml" />
+    <arg name="car_name"/>
+
     <rosparam file="$(arg vesc_config)" command="load" />
 
     <node pkg="vesc_ackermann" type="ackermann_to_vesc_node" name="ackermann_to_vesc">
@@ -17,5 +19,5 @@
 
     <node pkg="mushr_sim" type="fake_vesc_driver_node.py" name="vesc_driver" />
     <node pkg="vesc_ackermann" type="vesc_to_odom_node" name="vesc_to_odom" />
-    <node pkg="vesc_driver" name="throttle_interpolator" type="throttle_interpolator.py" />
+    <node pkg="vesc_driver" name="throttle_interpolator" type="throttle_interpolator.py" args="$(arg car_name)"/>
 </launch>

--- a/launch/vesc.launch.xml
+++ b/launch/vesc.launch.xml
@@ -2,7 +2,7 @@
 <launch>
     <arg name="mux_output_topic" default="ackermann_cmd" />
     <arg name="vesc_config" default="$(find mushr_sim)/config/vesc.yaml" />
-    <arg name="car_name" />
+    <arg name="car_name" default="car" />
 
     <rosparam file="$(arg vesc_config)" command="load" />
 

--- a/launch/vesc.launch.xml
+++ b/launch/vesc.launch.xml
@@ -2,13 +2,13 @@
 <launch>
     <arg name="mux_output_topic" default="ackermann_cmd" />
     <arg name="vesc_config" default="$(find mushr_sim)/config/vesc.yaml" />
-    <arg name="car_name"/>
+    <arg name="car_name" />
 
     <rosparam file="$(arg vesc_config)" command="load" />
 
     <node pkg="vesc_ackermann" type="ackermann_to_vesc_node" name="ackermann_to_vesc">
         <!-- Remap to make mux control work with the VESC -->
-	<remap from="ackermann_cmd" to="$(arg mux_output_topic)" />
+        <remap from="ackermann_cmd" to="$(arg mux_output_topic)" />
 
         <!-- Remap to make vesc have trapezoidal control on the throttle to avoid skipping -->
         <remap from="commands/motor/speed" to="commands/motor/unsmoothed_speed" />
@@ -19,5 +19,7 @@
 
     <node pkg="mushr_sim" type="fake_vesc_driver_node.py" name="vesc_driver" />
     <node pkg="vesc_ackermann" type="vesc_to_odom_node" name="vesc_to_odom" />
-    <node pkg="vesc_driver" name="throttle_interpolator" type="throttle_interpolator.py" args="$(arg car_name)"/>
+    <node pkg="vesc_driver" name="throttle_interpolator" type="throttle_interpolator.py" >
+        <param name="car_name" value="$(arg car_name)" />
+    </node>
 </launch>


### PR DESCRIPTION
## Status

**READY**

## Description
This PR updates `mushr_sim` to have default namespace `car` for the relevant launch files. 

I tested this by running it in sim and using rviz to test keyboard.

## Related PRs or Issues
List related PRs and Issues against other branches as described [here](https://help.github.com/articles/autolinked-references-and-urls/)

## Todos
- [x] Tests 
- [ ] Documentation

## Steps to Test or Reproduce
` roslaunch mushr_sim teleop.launch car_name:=car35` would start all nodes/tfs under `car35`.
Multicar version works as before, e.g. 
`roslaunch mushr_sim multi_teleop.launch car1_name:=car1 car2_name:=car35` 

## Specific Requests and Questions
This issue is independent of this PR, but just FYI, with `multicar_teleop.launch` you can't use rviz `initialpose` topic to set the car pose since there are two cars. I am not sure whether there's a good way to do this through rviz. You can still set the initial pose by directly sending message to `car#/initialpose`. For the single car version I just use `remap` to make it work in rviz.

The multicar version opens two keyboard teleop GUI, so I can still control the cars separately w/ WASD. One option might be to add a text input form there to take in initial pose. :) 
