### PR TITLE
Revamped multi car simulation

### DIFF
--- a/launch/multi_car.launch
+++ b/launch/multi_car.launch
@@ -1,5 +1,6 @@
 <launch>
+    <arg name="num_cars" default="2" />
     <node name="launchcars" pkg="mushr_sim" type="multi_car.py">
-        <param name="num_cars" type="int" value="2"/>
+        <param name="num_cars" type="int" value="$(arg num_cars)"/>
     </node>
 </launch>

--- a/launch/multi_car.launch
+++ b/launch/multi_car.launch
@@ -1,0 +1,3 @@
+<launch>
+    <node name="launchcars" pkg="mushr_sim" type="multi_car.py" />
+</launch>

--- a/launch/multi_car.launch
+++ b/launch/multi_car.launch
@@ -1,3 +1,5 @@
 <launch>
-    <node name="launchcars" pkg="mushr_sim" type="multi_car.py" />
+    <node name="launchcars" pkg="mushr_sim" type="multi_car.py">
+        <param name="num_cars" type="int" value="2"/>
+    </node>
 </launch>

--- a/launch/multi_teleop.launch
+++ b/launch/multi_teleop.launch
@@ -1,7 +1,7 @@
 <launch>
 
-    <arg name="car1_name" default="car1" />
-    <arg name="car2_name" default="car2" />
+    <arg name="car1_name" default="car0" />
+    <arg name="car2_name" default="car1" />
 
     <!-- Set to 1 if you want to run the map_server -->
     <arg name="map_server" value = "1"/>

--- a/launch/teleop.launch
+++ b/launch/teleop.launch
@@ -2,10 +2,10 @@
 <launch>
 
     <!-- Set to 1 if you want to run the map_server -->
-    <arg name="map_server" value = "1" />
+    <arg name="map_server" default="1" />
 
     <arg name="car_name" default="car" />
-
+	<arg name="racecar_color" default="" />
     <!-- Launch  map server-->
     <group if="$(arg map_server)">
         <include file="$(find mushr_sim)/launch/map_server.launch" />
@@ -22,7 +22,7 @@
             <!-- The colors of the racecar, should be of the form "-<platform_color>-<inset_color>" -->
             <!-- An empty string will result in the default URDF -->
               <!-- Check CMakeLists.txt of mushr_description for appropriate values -->
-            <arg name="racecar_color" value="" />
+            <arg name="racecar_color" value="$(arg racecar_color)" />
 
             <arg name="car_name" value="$(arg car_name)" />
          </include>

--- a/src/multi_car.py
+++ b/src/multi_car.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python2
+
+import rospy
+import roslaunch
+import sys
+uuid = roslaunch.rlutil.get_or_generate_uuid(None, False)
+roslaunch.configure_logging(uuid)
+
+#number of cars
+n=2
+
+launches = []
+mapserver = 1
+colors = ['','-green-black','-red-white','-teal-purple','-purple-gold']
+for x in range(n):
+    file_name='teleop.launch'
+    cli_args = ['mushr_sim', file_name, 'car_name:=car'+str(x),  'racecar_color:='+ colors[x%5], 'map_server:='+ str(mapserver)]
+    roslaunch_file = roslaunch.rlutil.resolve_launch_arguments(cli_args)[0]
+    roslaunch_args = cli_args[2:]
+    launches.append((roslaunch_file, roslaunch_args))
+    if(mapserver == 1):
+        mapserver = 0
+parent = roslaunch.parent.ROSLaunchParent(uuid, launches)
+parent.start()
+while not rospy.is_shutdown():
+    rospy.sleep(1)

--- a/src/multi_car.py
+++ b/src/multi_car.py
@@ -3,11 +3,12 @@
 import rospy
 import roslaunch
 import sys
+rospy.init_node("launchcars")
 uuid = roslaunch.rlutil.get_or_generate_uuid(None, False)
 roslaunch.configure_logging(uuid)
 
 #number of cars
-n=2
+n = rospy.get_param("~num_cars")
 
 launches = []
 mapserver = 1


### PR DESCRIPTION
## Status

**READY*

## Description
Enables users to simulate multiple cars 

## Related PRs or Issues
https://github.com/prl-mushr/mushr/pull/40
https://github.com/prl-mushr/mushr_base/pull/11

## Steps to Test or Reproduce
To run the simulation, run the following command
```sh
roslaunch mushr_sim multi_car.launch
```
Then, open multi_car.rviz (located in /mushr_utils/rviz) in rviz to show the cars.

To adjust the number of cars, modify the variable n in multi_car.py, then manually add the new cars in rviz

The cars are named starting with car0 and increasing in numerical order (i.e. car0, car1, car2, car3, etc.)

The cars also cycle through the different colors available, so that it's easier to differentiate between them in the visualization.

## Questions

Since this is my first major PR, I'd appreciate it if I could get feedback on it as far as formatting/documentation goes
