### PR TITLE
Add support for Foxglove teleop

### DIFF
--- a/config/foxglove_teleop.yaml
+++ b/config/foxglove_teleop.yaml
@@ -1,0 +1,3 @@
+keyboard_teleop:
+  speed: 2.0
+  max_steering_angle: 0.34

--- a/launch/foxglove_teleop.launch.xml
+++ b/launch/foxglove_teleop.launch.xml
@@ -1,0 +1,6 @@
+<!-- -*- mode: XML -*- -->
+<launch>
+    <rosparam command="load" file="$(find mushr_sim)/config/foxglove_teleop.yaml" />
+
+    <node pkg="mushr_sim" type="foxglove_teleop" name="foxglove_teleop" output="screen" />
+</launch>

--- a/launch/single_car.launch
+++ b/launch/single_car.launch
@@ -4,6 +4,8 @@
     <arg name="use_tf_prefix" default="true" />
     <arg name="fake_localization" default="true" />
     <arg name="teleop" default="true" />
+    <arg name="foxglove_teleop" default="1" />
+    <arg name="keyboard_teleop" default="0" />
 
     <!-- Could be racecar-mit, racecar-uw-tx2, or racecar-uw-nano -->
     <arg name="racecar_version" default="racecar-uw-nano" />
@@ -34,11 +36,6 @@
         <param if="$(arg use_tf_prefix)" name="tf_prefix" value="$(arg car_name)"/>
         <param name="robot_description" value="/$(arg car_name)/robot_description" />
     </node>
-
-    <!-- Set to 1 if you want to use foxglove teleop inputs instead of keyboard teleop -->
-    <arg name="foxglove_teleop" value = "1" />
-    <!-- Set to 1 if you want to use keyboard teleop inputs instead of foxglove teleop -->
-    <arg name="keyboard_teleop" value = "0" />
 
     <group if="$(arg foxglove_teleop)">
         <include file="$(find mushr_sim)/launch/foxglove_teleop.launch.xml" />

--- a/launch/single_car.launch
+++ b/launch/single_car.launch
@@ -35,7 +35,18 @@
         <param name="robot_description" value="/$(arg car_name)/robot_description" />
     </node>
 
-    <include if="$(arg teleop)" file="$(find mushr_sim)/launch/keyboard_teleop.launch.xml" />
+    <!-- Set to 1 if you want to use foxglove teleop inputs instead of keyboard teleop -->
+    <arg name="foxglove_teleop" value = "1" />
+    <!-- Set to 1 if you want to use keyboard teleop inputs instead of foxglove teleop -->
+    <arg name="keyboard_teleop" value = "0" />
+
+    <group if="$(arg foxglove_teleop)">
+        <include file="$(find mushr_sim)/launch/foxglove_teleop.launch.xml" />
+    </group>
+
+    <group if="$(arg keyboard_teleop)">
+        <include file="$(find mushr_sim)/launch/keyboard_teleop.launch.xml" />
+    </group>
 
     <group ns="mux">
         <!-- Spawn MUXs -->

--- a/launch/single_car_sim.launch
+++ b/launch/single_car_sim.launch
@@ -6,6 +6,8 @@
     <arg name="initial_x" default="0"/>
     <arg name="initial_y" default="0"/>
     <arg name="initial_theta" default="0"/>
+    <arg name="foxglove_teleop" default="1" />
+    <arg name="keyboard_teleop" default="0" />
 
     <!-- Could be racecar-mit, racecar-uw-tx2, or racecar-uw-nano -->
     <arg name="racecar_version" default="racecar-uw-nano" />
@@ -22,6 +24,8 @@
             <arg name="racecar_color" value="$(arg racecar_color)" />
             <arg name="use_tf_prefix" value="$(arg use_tf_prefix)" />
             <arg name="teleop" value="$(arg teleop)" />
+            <arg name="foxglove_teleop" value="$(arg foxglove_teleop)" />
+            <arg name="keyboard_teleop" value="$(arg keyboard_teleop)" />
         </include>
     </group>
 

--- a/launch/teleop.launch
+++ b/launch/teleop.launch
@@ -3,6 +3,18 @@
 
     <!-- Set to 1 if you want to run the map_server -->
     <arg name="map_server" value = "1" />
+    <!-- Set to 1 if you want to use foxglove teleop inputs instead of keyboard teleop -->
+    <arg name="foxglove_teleop" value = "1" />
+    <!-- Set to 1 if you want to use keyboard teleop inputs instead of foxglove teleop -->
+    <arg name="keyboard_teleop" value = "0" />
+
+    <!-- Start up websocket for docker container foxglove -->
+    <group if="$(arg foxglove_teleop)">
+        <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch" > 
+            <arg name="port" value="9090"/>
+        </include>
+    </group>
+
     <!-- We take a map path either as an environment variable or an argument.
          The environment variable has precedence. -->
     <arg name="_env_map" default="$(optenv MAP)" />
@@ -31,6 +43,10 @@
         <!-- An empty string will result in the default URDF -->
           <!-- Check CMakeLists.txt of mushr_description for appropriate values -->
         <arg name="racecar_color" value="" />
+
+        <arg name="foxglove_teleop" value="$(arg foxglove_teleop)" />
+        <arg name="keyboard_teleop" value="$(arg keyboard_teleop)" />
+
         <arg name="fake_localization" value="$(arg fake_localization)" />
         <arg name="initial_x" value="$(arg initial_x)"/>
         <arg name="initial_y" value="$(arg initial_y)"/>

--- a/scripts/foxglove_teleop
+++ b/scripts/foxglove_teleop
@@ -1,0 +1,39 @@
+#!/usr/bin/python3
+
+# Copyright (c) 2019, The Personal Robotics Lab, The MuSHR Team, The Contributors of MuSHR
+# License: BSD 3-Clause. See LICENSE.md file in root directory.
+
+import os
+import atexit
+import rospy
+from threading import Thread
+from mushr_sim.foxglove_teleop import FoxgloveTeleop
+
+
+class TeleopThread(Thread):
+    def __init__(self):
+        super(TeleopThread, self).__init__()
+
+    def run(self):
+        # Temporarily disable keyboard repeats
+        self.teleop = FoxgloveTeleop()
+
+    def shutdown(self):
+        self.teleop.root.quit()
+        super(TeleopThread, self).shutdown()
+
+
+def main():
+    rospy.init_node("foxglove_teleop")
+
+    teleop_thread = TeleopThread()
+    teleop_thread.start()
+    # Spin the main thread
+    rospy.spin()
+    # We either got SIGINT from control-C or ROS is otherwise coming down.
+    # Kill the GUI on the way out
+    teleop_thread.teleop.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/foxglove_teleop
+++ b/scripts/foxglove_teleop
@@ -15,7 +15,6 @@ class TeleopThread(Thread):
         super(TeleopThread, self).__init__()
 
     def run(self):
-        # Temporarily disable keyboard repeats
         self.teleop = FoxgloveTeleop()
 
     def shutdown(self):
@@ -31,7 +30,6 @@ def main():
     # Spin the main thread
     rospy.spin()
     # We either got SIGINT from control-C or ROS is otherwise coming down.
-    # Kill the GUI on the way out
     teleop_thread.teleop.shutdown()
 
 

--- a/src/mushr_sim/foxglove_teleop.py
+++ b/src/mushr_sim/foxglove_teleop.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2019, The Personal Robotics Lab, The MuSHR Team, The Contributors of MuSHR
+# License: BSD 3-Clause. See LICENSE.md file in root directory.
+import rospy
+from ackermann_msgs.msg import AckermannDriveStamped
+from geometry_msgs.msg import Twist
+import std_msgs
+
+
+class FoxgloveTeleop:
+    def __init__(self):
+        self.max_velocity = rospy.get_param("~speed", 2.0)
+        self.max_steering_angle = rospy.get_param("~max_steering_angle", 0.34)
+
+        self.state_pub = rospy.Publisher(
+            "mux/ackermann_cmd_mux/input/teleop", AckermannDriveStamped, queue_size=1
+        )
+
+        self.foxglove_inputs = rospy.Subscriber(
+            "foxglove/teleop", Twist, self.drive_cb, queue_size=1
+        )
+
+    def drive_cb(self, msg):
+        x = msg.linear.x
+        z = msg.linear.z
+
+        ack = AckermannDriveStamped()
+        ack.header = std_msgs.msg.Header()
+        ack.header.stamp = rospy.Time.now()
+        ack.header.frame_id = "map"
+
+        cmd_up = x == 1
+        cmd_down = x == -1
+        cmd_left = z == -1
+        cmd_right = z == 1
+
+        # In Foxglove, you can only currently press 1 button at a time,
+        # so assume that the direction is forward when turning
+
+        if cmd_up:
+            ack.drive.speed = self.max_velocity
+        elif cmd_down:
+            ack.drive.speed = -self.max_velocity
+        elif cmd_left:
+            ack.drive.speed = self.max_velocity
+            ack.drive.steering_angle = self.max_steering_angle
+        elif cmd_right:
+            ack.drive.speed = self.max_velocity
+            ack.drive.steering_angle = -self.max_steering_angle
+
+        if self.state_pub is not None:
+            self.state_pub.publish(ack)

--- a/src/mushr_sim/foxglove_teleop.py
+++ b/src/mushr_sim/foxglove_teleop.py
@@ -22,14 +22,15 @@ class FoxgloveTeleop:
         )
 
     def drive_cb(self, msg):
-        x = msg.linear.x
-        z = msg.linear.z
-
         ack = AckermannDriveStamped()
         ack.header = std_msgs.msg.Header()
         ack.header.stamp = rospy.Time.now()
         ack.header.frame_id = "map"
 
+        x = msg.linear.x
+        z = msg.linear.z
+
+        # x and z dictate the directions
         cmd_up = x == 1
         cmd_down = x == -1
         cmd_left = z == -1


### PR DESCRIPTION
## Description
For sims run in docker containers, we want to be able to have a natively supported visualization tool. We are considering switching to Foxglove from rviz. In order to be able to drive the car from the Foxglove teleop, we add in a small node that republishes received teleop commands from Foxglove, instead of the keyboard teleop (which does not work with the docker container). Note that the added node can be turned on and off from the launch files and used in tandum with the keyboard teleop (enable both) if desired. 

We have also made a feature request to Foxglove Studio for adding in keyboard driving options: [WASD/Arrows Support for Teleop Panel](https://github.com/foxglove/community/issues/196).

Currently, only one button at a time can be pressed from Foxglove studio, so we assume forward speed when turning. This can be changed once keyboard support is added.

When using with Foxglove teleop, set the teleop panel settings to the following:
<img width="470" alt="Screen Shot 2022-02-14 at 9 45 27 AM" src="https://user-images.githubusercontent.com/45296521/153925970-db7a17c1-2b13-42aa-b51c-7d4d9f24a5dc.png">

