### PR TITLE
Launch nav msg converter node along with mushr sim stack

### DIFF
--- a/launch/teleop.launch
+++ b/launch/teleop.launch
@@ -3,6 +3,7 @@
 
     <!-- Set to 1 if you want to run the map_server -->
     <arg name="map_server" value = "1" />
+    <arg name="nav_msg_converter" value = "1" />
     <!-- Set to 1 if you want to use foxglove teleop inputs instead of keyboard teleop -->
     <arg name="foxglove_teleop" value = "1" />
     <!-- Set to 1 if you want to use keyboard teleop inputs instead of foxglove teleop -->
@@ -30,6 +31,12 @@
     <group if="$(arg map_server)">
         <include file="$(find mushr_sim)/launch/map_server.launch">
             <arg name="map" value="$(eval _env_map if _env_map else map)" />
+        </include>
+    </group>
+
+    <!-- Launch  nav msg converter-->
+    <group if="$(arg nav_msg_converter)">
+        <include file="$(find mushr_base)/launch/includes/nav_msg_converter.launch">
         </include>
     </group>
 

--- a/src/mushr_sim/mushr_sim.py
+++ b/src/mushr_sim/mushr_sim.py
@@ -249,7 +249,7 @@ class SimulatedCar:
     def publish_updated_transforms(self, transform, changes):
         cur_pose = PoseStamped()
         cur_pose.header.frame_id = "map"
-        cur_pose.header.stamp = transform.header.stamp
+        cur_pose.header.stamp = transform.header.stamp - rospy.Duration(.5) # for visualization purposes, delay header stamp
         cur_pose.pose.position.x = (
                 self.odom_to_base_trans[0] + self.map_to_odom_trans[0]
         )


### PR DESCRIPTION
## Description
Launch the nav msg converter file from [this PR](https://github.com/prl-mushr/mushr_base/pull/12) when launching mushr teleop on sim. Also adds in a small change to reduce flickering in visualized messages which is the recommended fix by Foxglove devs.
