### PR TITLE
Added optional arguments for rosbridge port and websocket external po…

### DIFF
--- a/launch/teleop.launch
+++ b/launch/teleop.launch
@@ -10,9 +10,13 @@
     <arg name="keyboard_teleop" value = "0" />
 
     <!-- Start up websocket for docker container foxglove -->
+    <arg name="_rosbridge_port" default="$(optenv ROSBRIDGE_PORT)" />
+    <arg name="_rosbridge_websocket_external_port" default="$(optenv ROSBRIDGE_WEBSOCKET_EXTERNAL_PORT)" />
+
     <group if="$(arg foxglove_teleop)">
-        <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch" > 
-            <arg name="port" value="9090"/>
+        <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch" >
+            <arg name="port" value="$(eval _rosbridge_port if _rosbridge_port else 9090)"/>
+            <arg name="websocket_external_port" value="$(eval _rosbridge_websocket_external_port if _rosbridge_websocket_external_port else None)"/>
         </include>
     </group>
 


### PR DESCRIPTION
## Status

READY

## Description
Added optional arguments for rosbridge port and websocket external port in `teleop.launch` file.

## Related PRs or Issues
This PR is blocking https://github.com/prl-mushr/mushr/pull/110

## Steps to Test

Make sure the last step in the [quickstart tutorial](https://mushr.io/tutorials/noetic_quickstart/) `$ roslaunch mushr_sim teleop.launch` doesn't crash and verify you can use foxglove as before. The devcontainer CI test added in https://github.com/prl-mushr/mushr/pull/109 should be sufficient.